### PR TITLE
post_upload: Default to HTTPS archive.mozilla.org URLs in log output

### DIFF
--- a/post_upload/flags.go
+++ b/post_upload/flags.go
@@ -31,7 +31,7 @@ var Flags = []cli.Flag{
 		Usage: "Sets S3 bucket prefix"},
 	cli.StringFlag{
 		Name:  "url-prefix",
-		Value: "http://archive.mozilla.org/",
+		Value: "https://archive.mozilla.org/",
 		Usage: "Sets URL prefix. (Only affects output)"},
 	cli.StringFlag{
 		Name: "nightly-dir", Value: "nightly",


### PR DESCRIPTION
Since S3 supports HTTPS and the current default of HTTP is causing mixed content issues in [bug 1281644](https://bugzilla.mozilla.org/show_bug.cgi?id=1281644).